### PR TITLE
add: depends_on

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Terraform module to connect a Google Cloud Organization to Cloudbase.
 ```
 module "cloudbase" {
   source  = "Levetty/organization-cloudbase/google"
-  version = "0.0.3"
+  version = "0.0.4"
 
   project_id      = "xxx" # required
   organization_id = "xxx" # required

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ resource "google_service_account" "cloudbase_service_account" {
   account_id   = "cloudbase-sa-org-${random_string.unique_id.result}"
   display_name = "Cloudbase Service Account"
   project      = var.project_id
+  depends_on   = [google_project_service.enable_apis]
 }
 
 resource "google_organization_iam_custom_role" "cloudbase_project_custom_role" {
@@ -17,6 +18,7 @@ resource "google_organization_iam_custom_role" "cloudbase_project_custom_role" {
   permissions = var.enable_cnapp ? concat(
     var.cloudbase_project_role_permissions_cspm, var.cloudbase_project_role_permissions_cwpp
   ) : var.cloudbase_project_role_permissions_cspm
+  depends_on = [google_project_service.enable_apis]
 }
 
 resource "google_organization_iam_custom_role" "cloudbase_org_custom_role" {
@@ -24,24 +26,28 @@ resource "google_organization_iam_custom_role" "cloudbase_org_custom_role" {
   role_id     = "cloudbaseOrganizationPolicy${random_string.unique_id.result}"
   title       = "Cloudbase Organization Policy ${random_string.unique_id.result}"
   permissions = var.cloudbase_org_role_permissions
+  depends_on  = [google_project_service.enable_apis]
 }
 
 resource "google_organization_iam_member" "bind_security_reviewer_role" {
-  org_id = var.organization_id
-  role   = "roles/iam.securityReviewer"
-  member = "serviceAccount:${google_service_account.cloudbase_service_account.email}"
+  org_id     = var.organization_id
+  role       = "roles/iam.securityReviewer"
+  member     = "serviceAccount:${google_service_account.cloudbase_service_account.email}"
+  depends_on = [google_project_service.enable_apis]
 }
 
 resource "google_organization_iam_member" "bind_cloudbase_custom_role_prj" {
-  org_id = var.organization_id
-  role   = "organizations/${var.organization_id}/roles/${google_organization_iam_custom_role.cloudbase_project_custom_role.role_id}"
-  member = "serviceAccount:${google_service_account.cloudbase_service_account.email}"
+  org_id     = var.organization_id
+  role       = "organizations/${var.organization_id}/roles/${google_organization_iam_custom_role.cloudbase_project_custom_role.role_id}"
+  member     = "serviceAccount:${google_service_account.cloudbase_service_account.email}"
+  depends_on = [google_project_service.enable_apis]
 }
 
 resource "google_organization_iam_member" "bind_cloudbase_custom_role_org" {
-  org_id = var.organization_id
-  role   = "organizations/${var.organization_id}/roles/${google_organization_iam_custom_role.cloudbase_org_custom_role.role_id}"
-  member = "serviceAccount:${google_service_account.cloudbase_service_account.email}"
+  org_id     = var.organization_id
+  role       = "organizations/${var.organization_id}/roles/${google_organization_iam_custom_role.cloudbase_org_custom_role.role_id}"
+  member     = "serviceAccount:${google_service_account.cloudbase_service_account.email}"
+  depends_on = [google_project_service.enable_apis]
 }
 
 resource "google_project_service" "enable_apis" {


### PR DESCRIPTION
Prevent a 403 permission denied error by ensuring the API isn’t called before it’s enabled.
